### PR TITLE
Explicitly require packages before compiling

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -27,6 +27,7 @@ class statsite::install inherits statsite {
     cwd     => $version_path,
     command => 'make',
     creates => "${version_path}/statsite",
+    require => Package[$packages],
   }
 
   file { "${statsite::install_path}/current":


### PR DESCRIPTION
Explicitly `require` the `$packages` needed for compilation.  `ensure_packages` doesnt seem to guarantee they're actually available in time.