### PR TITLE
Add config option for `add_type_prefix`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ class { 'statsite':
   Should data be streamed to the stream_cmd in binary form instead of
   ASCI form. Defaults to 0.
 
+- `use_type_prefix`
+  Should prefixes with message type be added to the messages. Does not
+  affect global_prefix. Defaults to 1.
+
 - `histograms`
   An optional array of histogram configuration hashes with the following
   keys:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,6 +80,10 @@
 #   Should data be streamed to the stream_cmd in binary form instead of
 #   ASCI form. Defaults to 0.
 #
+# [*use_type_prefix*]
+#   Should prefixes with message type be added to the messages. Does not
+#   affect global_prefix. Defaults to 1.
+#
 # [*histograms*]
 #   An optional array of histogram configuration hashes with the following
 #   keys:
@@ -125,6 +129,7 @@ class statsite (
   $input_counter     = undef,
   $pid_file          = '/var/run/statsite.pid',
   $binary_stream     = 0,
+  $use_type_prefix   = 1,
   $histograms        = [],
   $packages          = $statsite::params::packages,
   $init_style        = $statsite::params::init_style

--- a/templates/config.erb
+++ b/templates/config.erb
@@ -17,6 +17,7 @@ input_counter = <%= @input_counter %>
 <%- end -%>
 pid_file = <%= @pid_file %>
 binary_stream = <%= @binary_stream %>
+use_type_prefix = <%= @use_type_prefix %>
 <%- @histograms.each do |histogram| -%>
 
 [histogram_<%= histogram['name'] %>]


### PR DESCRIPTION
This will allow a user to configure whether they want the prefixes for
types, eg: counts, gauges, timers.