### PR TITLE
Create statsite user since www-data does not exist

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,6 +16,15 @@ class statsite::config inherits statsite {
   $binary_stream  = $statsite::binary_stream
   $histograms     = $statsite::histograms
 
+  group { 'statsite':
+    ensure  => 'present',
+  }
+  user { 'statsite':
+    ensure  => 'present',
+    groups  => 'statsite',
+    require => Group['statsite'],
+  }
+
   if $statsite::stream_cmd {
     $stream_cmd = $statsite::stream_cmd
   } else {

--- a/templates/config.erb
+++ b/templates/config.erb
@@ -16,6 +16,7 @@ stream_cmd <%= @install_path %>/current/sinks/graphite.py <%= @graphite_host %> 
 input_counter = <%= @input_counter %>
 <%- end -%>
 pid_file = <%= @pid_file %>
+daemonize = 1
 binary_stream = <%= @binary_stream %>
 use_type_prefix = <%= @use_type_prefix %>
 extended_counters = <%= @extended_counters %>

--- a/templates/debian.erb
+++ b/templates/debian.erb
@@ -21,10 +21,10 @@ DESC="statsite"
 NAME=statsite
 DAEMON=<%= @install_path %>/current/statsite
 DAEMON_ARGS="-f <%= @config_file %>"
-PIDFILE=/var/run/$NAME.pid
+PIDFILE=<%= @pid_file %>
 SCRIPTNAME=/etc/init.d/$NAME
-DAEMON_USER=www-data
-DAEMON_GROUP=www-data
+DAEMON_USER=$NAME
+DAEMON_GROUP=$NAME
 
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0

--- a/templates/systemd.erb
+++ b/templates/systemd.erb
@@ -9,6 +9,7 @@ ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=on-failure
 RestartSec=42s
+User=statsite
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/upstart.erb
+++ b/templates/upstart.erb
@@ -14,5 +14,5 @@ respawn limit 5 30
 console none
 
 script
-  exec <%= @install_path %>/current/statsite -f <%= @config_file %> 2>/dev/null
+  exec sudo -u statsite <%= @install_path %>/current/statsite -f <%= @config_file %> 2>/dev/null
 end script


### PR DESCRIPTION
I had to make these changes because my debian systems do not have a www-data user. I also made some changes to get the pid file working properly. As long as the folder is writable by statsite the pid file is created.
