### PR TITLE
Ubuntu init_style changes

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,7 +7,12 @@ class statsite::params {
     }
     'Ubuntu' : {
       $packages   = ['scons', 'build-essential']
+      if versioncmp($::operatingsystemrelease, '15.04') >= 0 {
+      $init_style = 'systemd'
+      }
+      else {
       $init_style = 'upstart'
+      }
     }
     'RedHat': {
       $packages   = ['scons', 'make', 'gcc-c++']


### PR DESCRIPTION
Pick systemd as $init_style if Ubuntu 15.04 or newer. Systemd is default in these versions. This fixes startup problem with statsite.